### PR TITLE
Add return values to commands

### DIFF
--- a/Console/Command/CleanupIllegalProductImageMarkersNonExistingFiles.php
+++ b/Console/Command/CleanupIllegalProductImageMarkersNonExistingFiles.php
@@ -3,6 +3,7 @@
 namespace Tnegeli\M2CliTools\Console\Command;
 
 use Magento\Catalog\Model\Indexer\Product\Flat\State;
+use Magento\Framework\Console\Cli;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -60,14 +61,14 @@ Add the --dry-run option to just get the files that are unused.";
             $question = new ConfirmationQuestion('Are you sure you want to continue? [No] ', false);
             $this->questionHelper = $this->getHelper('question');
             if (!$this->questionHelper->ask($input, $output, $question)) {
-                return;
+                return Cli::RETURN_SUCCESS;
             }
         }
 
         $values = $this->getDbValues();
         if (count($values) == 0) {
             $output->writeln('You have no media gallery table entries.');
-            return;
+            return Cli::RETURN_SUCCESS;
         }
 
         $mediaDirectory = $this->filesystem->getDirectoryRead(DirectoryList::MEDIA);
@@ -88,7 +89,7 @@ Add the --dry-run option to just get the files that are unused.";
 
         if (count($imageMarkersToRemove) == 0) {
             $output->writeln("There are no image markers without a file. All is fine.");
-            return;
+            return Cli::RETURN_SUCCESS;
         }
 
         $output->writeln("The following items are left untouched: " . print_r($imageMarkersToKeep,
@@ -110,6 +111,8 @@ Add the --dry-run option to just get the files that are unused.";
             $output->writeln("The following items are save to be removed: " . print_r($imageMarkersToRemove,
                     true));
         }
+
+        return Cli::RETURN_SUCCESS;
     }
 
     private function reindexRequiredIndex($output)

--- a/Console/Command/CleanupIllegalProductMedia.php
+++ b/Console/Command/CleanupIllegalProductMedia.php
@@ -2,6 +2,7 @@
 
 namespace Tnegeli\M2CliTools\Console\Command;
 
+use Magento\Framework\Console\Cli;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -52,14 +53,14 @@ Add the --dry-run option to just get the files that are unused.";
             $question = new ConfirmationQuestion('Are you sure you want to continue? [No] ', false);
             $this->questionHelper = $this->getHelper('question');
             if (!$this->questionHelper->ask($input, $output, $question)) {
-                return;
+                return Cli::RETURN_SUCCESS;
             }
         }
 
         $values = $this->getDbValues();
         if (count($values) == 0) {
             $output->writeln('There are no illegal values in media gallery table.');
-            return;
+            return Cli::RETURN_SUCCESS;
         }
         echo "The following entries in " . $this->resource->getConnection()->getTableName('catalog_product_entity_media_gallery') . " are illegal: " . print_r($values,
                 true) . PHP_EOL;
@@ -69,6 +70,8 @@ Add the --dry-run option to just get the files that are unused.";
             $coreWrite->query($this->getDelete());
             $output->writeln("Entries where removed from media gallery table. The command catalog:images:resize should work now.");
         }
+
+        return Cli::RETURN_SUCCESS;
     }
 
     private function getSelect()

--- a/Console/Command/CleanupIllegalProductMediaNonExistingFiles.php
+++ b/Console/Command/CleanupIllegalProductMediaNonExistingFiles.php
@@ -2,6 +2,7 @@
 
 namespace Tnegeli\M2CliTools\Console\Command;
 
+use Magento\Framework\Console\Cli;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -59,7 +60,7 @@ Add the --dry-run option to just get the files that are unused.";
         $values = $this->getDbValues();
         if (count($values) == 0) {
             $output->writeln('You have no media gallery table entries.');
-            return;
+            return Cli::RETURN_SUCCESS;
         }
 
         $mediaDirectory = $this->filesystem->getDirectoryRead(DirectoryList::MEDIA);
@@ -76,7 +77,7 @@ Add the --dry-run option to just get the files that are unused.";
         }
         if (count($mediaGalleryValuesToRemove) == 0) {
             $output->writeln("There are no media gallery entries without a file. All is fine.");
-            return;
+            return Cli::RETURN_SUCCESS;
         }
 
         if (!$isDryRun) {
@@ -89,6 +90,8 @@ Add the --dry-run option to just get the files that are unused.";
             $output->writeln("The following items are save to be removed: " . print_r($mediaGalleryValuesToRemove,
                     true));
         }
+
+        return Cli::RETURN_SUCCESS;
     }
 
     private function getSelect()

--- a/Console/Command/CleanupUnusedCategoryMedia.php
+++ b/Console/Command/CleanupUnusedCategoryMedia.php
@@ -2,6 +2,7 @@
 
 namespace Tnegeli\M2CliTools\Console\Command;
 
+use Magento\Framework\Console\Cli;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -55,7 +56,7 @@ Add the --delete option to delete the files, instead of doing a backup";
             $question = new ConfirmationQuestion( 'Are you sure you want to continue? [No] ', false );
             $this->questionHelper = $this->getHelper( 'question' );
             if (!$this->questionHelper->ask( $input, $output, $question )) {
-                return;
+                return Cli::RETURN_SUCCESS;
             }
         }
 
@@ -65,7 +66,7 @@ Add the --delete option to delete the files, instead of doing a backup";
             $question = new ConfirmationQuestion( 'Are you sure you want to continue? [No] ', false );
             $this->questionHelper = $this->getHelper( 'question' );
             if (!$this->questionHelper->ask( $input, $output, $question )) {
-                return;
+                return Cli::RETURN_SUCCESS;
             }
         }
 
@@ -126,6 +127,8 @@ Add the --delete option to delete the files, instead of doing a backup";
         if (!$isDelete && !$isDryRun) {
             $output->writeln( "Files were moved to the following backup location: " . $backupDir );
         }
+
+        return Cli::RETURN_SUCCESS;
     }
 
     private function getDbValues ()

--- a/Console/Command/CleanupUnusedProductMedia.php
+++ b/Console/Command/CleanupUnusedProductMedia.php
@@ -4,6 +4,7 @@ namespace Tnegeli\M2CliTools\Console\Command;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Console\Cli;
 use Magento\Framework\Filesystem;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
@@ -23,7 +24,8 @@ class CleanupUnusedProductMedia extends Command
 
     public function __construct(
         Filesystem $filesystem,
-        ResourceConnection $resource
+        ResourceConnection $resource,
+        \Magento\Framework\Setup\ModuleDataSetupInterface $moduleDataSetup
     ) {
         $this->filesystem = $filesystem;
         $this->resource = $resource;
@@ -52,7 +54,7 @@ Add the --delete option to delete the files, instead of doing a backup";
             $question = new ConfirmationQuestion('Are you sure you want to continue? [No] ', false);
             $this->questionHelper = $this->getHelper('question');
             if (!$this->questionHelper->ask($input, $output, $question)) {
-                return;
+                return Cli::RETURN_SUCCESS;
             }
         }
 
@@ -62,7 +64,7 @@ Add the --delete option to delete the files, instead of doing a backup";
             $question = new ConfirmationQuestion('Are you sure you want to continue? [No] ', false);
             $this->questionHelper = $this->getHelper('question');
             if (!$this->questionHelper->ask($input, $output, $question)) {
-                return;
+                return Cli::RETURN_SUCCESS;
             }
         }
 
@@ -126,6 +128,8 @@ Add the --delete option to delete the files, instead of doing a backup";
         if (!$isDelete && !$isDryRun) {
             $output->writeln("Files were moved to the following backup location: " . $backupDir);
         }
+
+        return Cli::RETURN_SUCCESS;
     }
 
     private function getDbValues()

--- a/Console/Command/CleanupUnusedProductMedia.php
+++ b/Console/Command/CleanupUnusedProductMedia.php
@@ -24,8 +24,7 @@ class CleanupUnusedProductMedia extends Command
 
     public function __construct(
         Filesystem $filesystem,
-        ResourceConnection $resource,
-        \Magento\Framework\Setup\ModuleDataSetupInterface $moduleDataSetup
+        ResourceConnection $resource
     ) {
         $this->filesystem = $filesystem;
         $this->resource = $resource;

--- a/Console/Command/CleanupUnusedSwatchesMedia.php
+++ b/Console/Command/CleanupUnusedSwatchesMedia.php
@@ -2,6 +2,7 @@
 
 namespace Tnegeli\M2CliTools\Console\Command;
 
+use Magento\Framework\Console\Cli;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -61,7 +62,7 @@ Add the --delete option to delete the files, instead of doing a backup";
             $question = new ConfirmationQuestion( 'Are you sure you want to continue? [No] ', false );
             $this->questionHelper = $this->getHelper( 'question' );
             if (!$this->questionHelper->ask( $input, $output, $question )) {
-                return;
+                return Cli::RETURN_SUCCESS;
             }
         }
 
@@ -71,7 +72,7 @@ Add the --delete option to delete the files, instead of doing a backup";
             $question = new ConfirmationQuestion( 'Are you sure you want to continue? [No] ', false );
             $this->questionHelper = $this->getHelper( 'question' );
             if (!$this->questionHelper->ask( $input, $output, $question )) {
-                return;
+                return Cli::RETURN_SUCCESS;
             }
         }
 
@@ -168,6 +169,8 @@ Add the --delete option to delete the files, instead of doing a backup";
         if (!$isDelete && !$isDryRun) {
             $output->writeln( "Files were moved to the following backup location: " . $backupDir );
         }
+
+        return Cli::RETURN_SUCCESS;
     }
 
     private function backupFile ( $imageDir, $backupDir, $file )

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "tnegeli/m2clitools",
   "description": "Some nice commands to cleanup media files and tables on production systems",
   "type": "magento2-module",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": [
     "MIT"
   ],

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Tnegeli_M2CliTools" setup_version="1.5.2">
-
-    </module>
+    <module name="Tnegeli_M2CliTools"/>
 </config>


### PR DESCRIPTION
This PR adds return values to the `execute` methods for all commands. I was getting an error without them:

```
There is an error in /Sites/magento/vendor/symfony/console/Command/Command.php at line: 301
Return value of "Tnegeli\M2CliTools\Console\Command\CleanupUnusedProductMedia\Interceptor::execute()" must be of the type int, "null" returned.
```

I also removed the `setup_version` from module.xml (#6).